### PR TITLE
[WIP] Add module to package.json and gitignore dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+!dist/stylebuddy.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Generate encapsulated css inline styles which are extremely configurable",
   "main": "dist/stylebuddy.js",
+  "module": "src/stylebuddy.js",
   "scripts": {
     "test": "tropic ./src/*.test.js",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylebuddy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate encapsulated css inline styles which are extremely configurable",
   "main": "dist/stylebuddy.js",
   "module": "src/stylebuddy.js",


### PR DESCRIPTION
Needs local testing w/ Rollup or so

- Rollup and webpack2 should be able to use the "module" from package.json and use the ES6 source
- Using gitignore and npmignore we should be able to publish the dist without having it in git
